### PR TITLE
fix(docker): simplify watchdog URL logic for non-cluster environments

### DIFF
--- a/src/vui_common/configs/watchdog.py
+++ b/src/vui_common/configs/watchdog.py
@@ -8,8 +8,6 @@ class WatchdogConfig:
     @staticmethod
     def _get_watchdog_url():
         """Determines the Watchdog URL based on K8s mode."""
-        if os.getenv('K8S_IN_CLUSTER_MODE', 'False').lower() == 'true':
-            watchdog_url = os.getenv('WATCHDOG_URL', '').strip()
-            watchdog_port = os.getenv('WATCHDOG_PORT', '').strip()
-            return f"{watchdog_url}:{watchdog_port}" if watchdog_url and watchdog_port else '127.0.0.1:8002'
-        return '127.0.0.1:8002'
+        watchdog_url = os.getenv('WATCHDOG_URL', '127.0.0.1').strip()
+        watchdog_port = os.getenv('WATCHDOG_PORT', '8002').strip()
+        return f"{watchdog_url}:{watchdog_port}"


### PR DESCRIPTION
Defaulted WATCHDOG_URL and WATCHDOG_PORT to localhost values, removing the need to check for K8S_IN_CLUSTER_MODE. This ensures compatibility in Docker environments without requiring cluster-specific configuration.